### PR TITLE
Check-in source tree for commit hash f8cb50a45

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,34 +1,31 @@
 [package]
 name = "k"
-version = "0.22.0"
+version = "0.18.0"
 authors = ["Takashi Ogura <t.ogura@gmail.com>"]
 description = "k is for kinematics"
 license = "Apache-2.0"
 keywords = ["kinematics", "robotics", "ik"]
 categories = ["algorithms"]
-repository = "https://github.com/openrr/k"
+repository = "https://github.com/OTL/k"
 documentation = "http://docs.rs/k"
 readme = "README.md"
 edition = "2018"
+build = "build.rs"
 
-[features]
-default = []
-serde-serialize = ["nalgebra/serde-serialize", "serde"]
-
-# Note: nalgebra, simba, urdf-rs, and serde are public dependencies.
 [dependencies]
+nalgebra = "0.23"
+urdf-rs = "0.5"
 log = "0.4"
-nalgebra = "0.25"
 simba = "0.3"
 thiserror = "1.0"
-urdf-rs = "0.6"
 
-serde = { version = "1.0", features = ["derive"], optional = true }
+[build-dependencies]
+skeptic = "0.13"
 
 [dev-dependencies]
-doc-comment = "0.3"
-kiss3d = "0.29"
-rand = "0.8"
+skeptic = "0.13"
+kiss3d = "0.24"
+rand = "0.7"
 
 #[profile.release]
 #debug = true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# `k`: Kinematics library for rust-lang
-
- ![Build and Test](https://github.com/openrr/k/workflows/Rust/badge.svg) [![crates.io](https://img.shields.io/crates/v/k.svg)](https://crates.io/crates/k) [![codecov](https://codecov.io/gh/openrr/k/branch/main/graph/badge.svg?token=A0MGJ1V6US)](https://codecov.io/gh/openrr/k) [![docs](https://docs.rs/k/badge.svg)](https://docs.rs/k)
+# `k`: Kinematics library for rust-lang [![Build Status](https://travis-ci.org/OTL/k.svg?branch=master)](https://travis-ci.org/OTL/k) [![crates.io](https://img.shields.io/crates/v/k.svg)](https://crates.io/crates/k)
 
 `k` has below functionalities.
 
@@ -12,7 +10,7 @@
 
 See [Document](http://docs.rs/k) and examples/ for more details.
 
-API is unstable.
+API is unstable. 
 
 ## Requirements to build examples
 
@@ -65,7 +63,7 @@ fn main() {
     target.translation.vector.z += 0.1;
 
     // Create IK solver with default settings
-    let solver = k::JacobianIkSolver::default();
+    let solver = k::JacobianIKSolver::default();
 
     // Create a set of joints from end joint
     let arm = k::SerialChain::from_end(target_link);

--- a/benches/fk.rs
+++ b/benches/fk.rs
@@ -35,18 +35,6 @@ test bench_rctree_ik ... bench:      10,622 ns/iter (+/- 1,203)
 test bench_rctree            ... bench:       1,855 ns/iter (+/- 165)
 test bench_rctree_set_joints ... bench:         186 ns/iter (+/- 6)
 test bench_rctree_ik ... bench:       8,640 ns/iter (+/- 364)
-
-## v0.19.0 on Desktop (AMD Ryzen 9 3950X 16-Core Processor, 3.5GHz - 64GB)
-
-test bench_rctree            ... bench:       1,293 ns/iter (+/- 17)
-test bench_rctree_set_joints ... bench:          98 ns/iter (+/- 2)
-test bench_rctree_ik ... bench:       4,394 ns/iter (+/- 73)
-
-## v0.20.0(Arc) on Desktop (AMD Ryzen 9 3950X 16-Core Processor, 3.5GHz - 64GB)
-
-test bench_rctree            ... bench:       1,803 ns/iter (+/- 21)
-test bench_rctree_set_joints ... bench:         204 ns/iter (+/- 17)
-test bench_rctree_ik ... bench:       5,985 ns/iter (+/- 65)
 */
 
 fn generate_random_joint_angles_from_limits<T>(limits: &Vec<Option<k::joint::Range<T>>>) -> Vec<T>

--- a/benches/ik.rs
+++ b/benches/ik.rs
@@ -13,7 +13,7 @@ fn bench_tree_ik(robot: &k::Chain<f64>, target_link: &str, b: &mut test::Bencher
     arm.update_transforms();
     let mut target = target_node.world_transform().unwrap();
     target.translation.vector[0] += 0.02;
-    let solver = k::JacobianIkSolver::new(0.001, 0.01, 0.8, 10);
+    let solver = k::JacobianIKSolver::new(0.001, 0.01, 0.8, 10);
     b.iter(|| {
         solver.solve(&arm, &target).unwrap();
         arm.set_joint_positions(&angles).unwrap();

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    skeptic::generate_doc_tests(&["README.md"]);
+}

--- a/examples/interactive_ik.rs
+++ b/examples/interactive_ik.rs
@@ -16,7 +16,7 @@
 use nalgebra as na;
 
 use k::prelude::*;
-use k::{connect, JacobianIkSolver, JointType, NodeBuilder};
+use k::{connect, JacobianIKSolver, JointType, NodeBuilder};
 use kiss3d::camera::ArcBall;
 use kiss3d::event::{Action, Key, WindowEvent};
 use kiss3d::light::Light;
@@ -163,7 +163,7 @@ fn main() {
     let eye = Point3::new(0.5f32, 1.0, 2.0);
     let at = Point3::new(0.0f32, 0.0, 0.0);
     let mut arc_ball = ArcBall::new(eye, at);
-    let mut solver = JacobianIkSolver::default();
+    let mut solver = JacobianIKSolver::default();
     //solver.set_nullspace_function(Box::new(|vec| vec.iter().map(|x| -x).collect()));
     let _ = create_ground(&mut window);
 

--- a/examples/interactive_ik_scara.rs
+++ b/examples/interactive_ik_scara.rs
@@ -16,7 +16,7 @@
 use nalgebra as na;
 
 use k::prelude::*;
-use k::{connect, JacobianIkSolver, JointType, NodeBuilder};
+use k::{connect, JacobianIKSolver, JointType, NodeBuilder};
 use kiss3d::camera::ArcBall;
 use kiss3d::event::{Action, Key, WindowEvent};
 use kiss3d::light::Light;
@@ -134,7 +134,7 @@ fn main() {
     let at = Point3::new(0.0f32, 0.0, 0.0);
     let mut arc_ball = ArcBall::new(eye, at);
 
-    let solver = JacobianIkSolver::default();
+    let solver = JacobianIKSolver::default();
     let _ = create_ground(&mut window);
 
     while window.render_with_camera(&mut arc_ball) {

--- a/examples/urdf.rs
+++ b/examples/urdf.rs
@@ -38,7 +38,7 @@ fn main() {
     target.translation.vector.z += 0.1;
 
     // Create IK solver with default settings
-    let solver = k::JacobianIkSolver::default();
+    let solver = k::JacobianIKSolver::default();
 
     // Create a set of joints from end joint
     let arm = k::SerialChain::from_end(target_link);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,7 +18,6 @@ use thiserror::Error;
 
 /// The reason of joint error
 #[derive(Debug, Clone, Error)]
-#[non_exhaustive]
 pub enum Error {
     /// Failed to set joint angle because the input is out of range or it is fixed joint
     #[error(

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -64,7 +64,7 @@ where
 
     chain.update_transforms();
     chain.iter().for_each(|node| {
-        if let Some(trans) = node.world_transform() {
+        if let Some(trans) = node.joint().world_transform() {
             if let Some(ref link) = *node.link() {
                 let inertia_trans = trans * link.inertial.origin().translation;
                 com += inertia_trans.translation.vector * link.inertial.mass;

--- a/src/joint/joint.rs
+++ b/src/joint/joint.rs
@@ -53,7 +53,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// use nalgebra as na;
+    /// extern crate nalgebra as na;
+    /// extern crate k;
     ///
     /// // create fixed joint
     /// let fixed = k::Joint::<f32>::new("f0", k::JointType::Fixed);
@@ -83,7 +84,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// use nalgebra as na;
+    /// extern crate nalgebra as na;
+    /// extern crate k;
     ///
     /// // Create fixed joint
     /// let mut fixed = k::Joint::<f32>::new("f0", k::JointType::Fixed);
@@ -111,9 +113,9 @@ where
             if !range.is_valid(position) {
                 return Err(Error::OutOfLimitError {
                     joint_name: self.name.to_string(),
-                    position: na::try_convert(position).unwrap_or_default(),
-                    max_limit: na::try_convert(range.max).unwrap_or_default(),
-                    min_limit: na::try_convert(range.min).unwrap_or_default(),
+                    position: na::convert(position),
+                    max_limit: na::convert(range.max),
+                    min_limit: na::convert(range.min),
                 });
             }
         }
@@ -130,7 +132,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// use nalgebra as na;
+    /// extern crate nalgebra as na;
+    /// extern crate k;
     ///
     /// // Create rotational joint with Y-axis
     /// let mut rot = k::Joint::<f64>::new("r0", k::JointType::Rotational { axis: na::Vector3::y_axis() });
@@ -208,7 +211,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// use nalgebra as na;
+    /// extern crate nalgebra as na;
+    /// extern crate k;
     ///
     /// // Create linear joint with X-axis
     /// let mut lin = k::Joint::<f64>::new("l0", k::JointType::Linear { axis: na::Vector3::x_axis() });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,6 @@
 //!
 //! See `Chain` as the top level interface.
 //!
-
-#[cfg(doctest)]
-doc_comment::doctest!("../README.md");
-
 mod chain;
 mod errors;
 mod funcs;
@@ -51,7 +47,4 @@ pub use self::node::{Node, NodeBuilder};
 // include Real for backwards compatibility purposes
 // (na::Real used to be the name, so we used to re-export k::Real)
 pub use na::{Isometry3, RealField as Real, RealField, Translation3, UnitQuaternion, Vector3};
-// export everything
-pub use nalgebra;
-pub use simba;
 pub use simba::scalar::{SubsetOf, SupersetOf};

--- a/tests/test_ik.rs
+++ b/tests/test_ik.rs
@@ -1,5 +1,6 @@
-use k::connect;
-use nalgebra as na;
+#[macro_use]
+extern crate k;
+extern crate nalgebra as na;
 
 #[cfg(test)]
 mod tests {
@@ -125,7 +126,7 @@ mod tests {
         arm.set_joint_positions(&angles).unwrap();
         let poses = arm.update_transforms();
         let init_pose = poses.last().unwrap();
-        let solver = k::JacobianIkSolver::new(0.001, 0.001, 0.5, 100);
+        let solver = k::JacobianIKSolver::new(0.001, 0.001, 0.5, 100);
         solver.solve(&arm, &init_pose).unwrap();
         let end_angles = arm.joint_positions();
         for (init, end) in angles.iter().zip(end_angles.iter()) {
@@ -140,7 +141,7 @@ mod tests {
         arm.set_joint_positions(&angles).unwrap();
         let poses = arm.update_transforms();
         let init_pose = poses.last().unwrap();
-        let solver = k::JacobianIkSolver::new(0.001, 0.001, 0.8, 100);
+        let solver = k::JacobianIKSolver::new(0.001, 0.001, 0.8, 100);
         // set different angles
         arm.set_joint_positions(&[0.4, 0.1, 0.1, -1.0, 0.1, 0.1])
             .unwrap();


### PR DESCRIPTION
`catkin build` seems to ignore local Cargo configurations, i.e. pointers
to locally vendored Cargo sources. As such, I will allow Corrosion
- when invoked through `catkin build` - direct access to this commit hash
(f8cb50a45) on this fork instead.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>